### PR TITLE
fix the issue with 'int' getter on Mobile SDKs

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -73,7 +73,9 @@ func (ps *Props) GetBool(key string) (val bool, err error) {
 
 func (ps *Props) GetInt(key string) (val int, err error) {
 	if x, found := ps.m[key]; found {
-		if f, ok := x.(float64); ok {
+		if i, ok := x.(int); ok {
+			val = i
+		} else if f, ok := x.(float64); ok {
 			val = int(f)
 		} else {
 			err = fmt.Errorf("Prop type: %q is not a number", key)


### PR DESCRIPTION
When an integer value is set using `setInt(_:,val:)` API, getting the value of the same key results in the following error

```swift
props.setInt("history_order", val: 1)
props.getInt("history_order")

Error Domain=go Code=1 "Prop type: "the_key" is not a number" UserInfo={NSLocalizedDescription=Prop type: "the_key" is not a number
```

The issue was caught during development of the Swift SDK and was recorded in this test class: [NINLowLevelClientPropsTests.swift](https://github.com/somia/ninchat-sdk-ios-swift/blob/33c4853a28b47dfe1d93a38131430355d95fb907/NinchatSDKSwiftTests/NINLowLevelClientPropsTests.swift#L11), in particular, in [this test function](https://github.com/somia/ninchat-sdk-ios-swift/blob/33c4853a28b47dfe1d93a38131430355d95fb907/NinchatSDKSwiftTests/NINLowLevelClientPropsTests.swift#L61)﻿
